### PR TITLE
Allow environment variables and secrets to be injected into ECS task definition

### DIFF
--- a/examples/secrets/README.md
+++ b/examples/secrets/README.md
@@ -1,0 +1,3 @@
+# Secrets
+
+This example shows how to pass in secrets to the ECS task using AWS Secrets Manager or AWS SSM parameters.

--- a/examples/secrets/main.tf
+++ b/examples/secrets/main.tf
@@ -1,0 +1,27 @@
+module "ecs-compute" {
+  source  = "orchestra-hq/ecs-compute/aws"
+  version = "0.0.3"
+
+  name_prefix          = "awesome-compute"
+  region               = "eu-west-2"
+  integrations         = ["dbt-core", "python"]
+  orchestra_account_id = "4a6a45ca-5549-4c53-bca4-43a76e1bab2c"
+
+  task_secrets = [
+    {
+      # AWS Secrets Manager.
+      name      = "API_KEY"
+      valueFrom = "arn:aws:secretsmanager:ap-southeast-2:0123456789012:secret:test-api-key-1234"
+    },
+    {
+      # You can also use AWS SSM parameters as secrets. If the parameter is in the same region as the ECS task, you only require the name.
+      name      = "SSM_PARAMETER_SAME_REGION"
+      valueFrom = "secret-param"
+    },
+    {
+      # If the AWS SSM parameter is in a different region to the ECS task, you need to provide the full ARN.
+      name      = "SSM_PARAMETER_DIFFERENT_REGION"
+      valueFrom = "arn:aws:ssm:ap-southeast-2:123456789012:parameter/secret-param"
+    }
+  ]
+}

--- a/examples/standard/README.md
+++ b/examples/standard/README.md
@@ -1,0 +1,3 @@
+# Standard
+
+This example shows the basic usage of this module. It will deploy resources in the `eu-west-2` region for the `dbt-core` and `python` integrations.

--- a/examples/standard/main.tf
+++ b/examples/standard/main.tf
@@ -7,5 +7,5 @@ module "ecs-compute" {
   tags = {
     Owner = "Awesome Team"
   }
-  orchestra_aws_account_id = "4a6a45ca-5549-4c53-bca4-43a76e1bab2c"
+  orchestra_account_id = "4a6a45ca-5549-4c53-bca4-43a76e1bab2c"
 }

--- a/task_definition.tf
+++ b/task_definition.tf
@@ -39,8 +39,8 @@ resource "aws_ecs_task_definition" "task_definition" {
       image       = "${local.ecr_account_mapping[var.orchestra_aws_account_id]}.dkr.ecr.${var.region}.amazonaws.com/${each.value.image}:${each.value.python_version}_PIP-${var.image_tags[each.value.integration]}"
       cpu         = each.value.cpu
       memory      = each.value.memory
-      environment = [],
-      secrets     = [],
+      environment = var.task_env_vars,
+      secrets     = var.task_secrets,
       logConfiguration = {
         logDriver = "awslogs"
         options = {

--- a/variables.tf
+++ b/variables.tf
@@ -91,3 +91,23 @@ variable "orchestra_account_id" {
   description = "Your Orchestra account ID, which can be found in the Account Settings page on Orchestra."
   type        = string
 }
+
+variable "task_env_vars" {
+  description = "Environment variables to set on the ECS task when it runs."
+  type        = list(map(string))
+  default     = []
+  validation {
+    condition     = alltrue([for env in var.task_env_vars : length(env) == 2 && contains(keys(env), "name") && contains(keys(env), "value")])
+    error_message = "Each environment variable must be of the form { name = string, value = string }."
+  }
+}
+
+variable "task_secrets" {
+  description = "Secrets to set on the ECS task when it runs. This will inject sensitive data into your containers as environment variables."
+  type        = list(map(string))
+  default     = []
+  validation {
+    condition     = alltrue([for secret in var.task_secrets : length(secret) == 2 && contains(keys(secret), "name") && contains(keys(secret), "valueFrom")])
+    error_message = "Each secret must be of the form { name = string, valueFrom = string }."
+  }
+}


### PR DESCRIPTION
- Update `task_definition.tf` to allow environment and secrets to be injected
- Add variables with validation
- Update examples