### PR TITLE
Ensure module gives correct permissions to ECS execution role if secrets are to be injected

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,14 @@ No modules.
 | [aws_ecs_cluster.ecs_compute_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster) | resource |
 | [aws_ecs_task_definition.task_definition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
 | [aws_iam_policy.ecs_compute_task_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.ecs_task_get_secrets_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.role_assumed_from_orchestra_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.compute_execute_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.ecs_compute_task_roles](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.role_assumed_from_orchestra](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.compute_execute_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ecs_compute_task_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.ecs_task_get_secrets_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.role_assumed_from_orchestra_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_kms_alias.orchestra_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.orchestra_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
@@ -46,6 +48,7 @@ No modules.
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy.ecs_task_execution_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_iam_policy_document.ecs_compute_task_role_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.ecs_task_get_secrets_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.role_assumed_from_orchestra_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
@@ -64,6 +67,8 @@ No modules.
 | <a name="input_orchestra_aws_account_id"></a> [orchestra\_aws\_account\_id](#input\_orchestra\_aws\_account\_id) | The Orchestra AWS account ID. Note: this is provided by default and does not need to be set manually. | `string` | `"355563318157"` | no |
 | <a name="input_region"></a> [region](#input\_region) | The AWS region. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to all deployed resources ('Application' and 'DeployedBy' are included by default but can be overridden). | `map(string)` | `{}` | no |
+| <a name="input_task_env_vars"></a> [task\_env\_vars](#input\_task\_env\_vars) | Environment variables to set on the ECS task when it runs. | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_task_secrets"></a> [task\_secrets](#input\_task\_secrets) | Secrets to set on the ECS task when it runs. This will inject sensitive data into your containers as environment variables. The full ARNs of the secrets must be provided for this module. | <pre>list(object({<br/>    name      = string<br/>    valueFrom = string<br/>  }))</pre> | `[]` | no |
 
 ## Outputs
 

--- a/examples/secrets/README.md
+++ b/examples/secrets/README.md
@@ -1,3 +1,22 @@
 # Secrets
 
-This example shows how to pass in secrets to the ECS task using AWS Secrets Manager or AWS SSM parameters.
+This example shows how to pass in secrets to the ECS task using AWS Secrets Manager or AWS SSM parameters. The full ARNs of the secrets must be provided for this module.
+
+The module will create a suitable IAM policy in order for the ECS execution role to access the secrets. If the secrets are encrypted using a customer managed key, then you will additionally require `kms:Decrypt` permissions to be attached to the execution role. This needs to be done separately from the module:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt"
+      ],
+      "Resource": [
+        "arn:aws:kms:region:aws_account_id:key/key_id"
+      ]
+    }
+  ]
+}
+```

--- a/examples/secrets/main.tf
+++ b/examples/secrets/main.tf
@@ -14,12 +14,7 @@ module "ecs-compute" {
       valueFrom = "arn:aws:secretsmanager:ap-southeast-2:0123456789012:secret:test-api-key-1234"
     },
     {
-      # You can also use AWS SSM parameters as secrets. If the parameter is in the same region as the ECS task, you only require the name.
-      name      = "SSM_PARAMETER_SAME_REGION"
-      valueFrom = "secret-param"
-    },
-    {
-      # If the AWS SSM parameter is in a different region to the ECS task, you need to provide the full ARN.
+      # AWS SSM parameter - the full ARN must be provided for this module.
       name      = "SSM_PARAMETER_DIFFERENT_REGION"
       valueFrom = "arn:aws:ssm:ap-southeast-2:123456789012:parameter/secret-param"
     }

--- a/execute_role.tf
+++ b/execute_role.tf
@@ -26,3 +26,33 @@ resource "aws_iam_role_policy_attachment" "compute_execute_role_policy_attachmen
   role       = aws_iam_role.compute_execute_role.name
   policy_arn = data.aws_iam_policy.ecs_task_execution_role_policy.arn
 }
+
+data "aws_iam_policy_document" "ecs_task_get_secrets_policy" {
+  count = length(var.task_secrets) > 0 ? 1 : 0
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "ssm:GetParameters",
+    ]
+    resources = [
+      for secret in var.task_secrets :
+      secret.valueFrom
+    ]
+  }
+}
+
+resource "aws_iam_policy" "ecs_task_get_secrets_policy" {
+  count = length(var.task_secrets) > 0 ? 1 : 0
+
+  name   = "${var.name_prefix}-orchestra-ecs-get-secrets-${random_id.random_suffix.hex}"
+  policy = data.aws_iam_policy_document.ecs_task_get_secrets_policy[0].json
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_get_secrets_policy_attachment" {
+  count = length(var.task_secrets) > 0 ? 1 : 0
+
+  role       = aws_iam_role.compute_execute_role.name
+  policy_arn = aws_iam_policy.ecs_task_get_secrets_policy[0].arn
+}

--- a/variables.tf
+++ b/variables.tf
@@ -94,20 +94,18 @@ variable "orchestra_account_id" {
 
 variable "task_env_vars" {
   description = "Environment variables to set on the ECS task when it runs."
-  type        = list(map(string))
-  default     = []
-  validation {
-    condition     = alltrue([for env in var.task_env_vars : length(env) == 2 && contains(keys(env), "name") && contains(keys(env), "value")])
-    error_message = "Each environment variable must be of the form { name = string, value = string }."
-  }
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  default = []
 }
 
 variable "task_secrets" {
-  description = "Secrets to set on the ECS task when it runs. This will inject sensitive data into your containers as environment variables."
-  type        = list(map(string))
-  default     = []
-  validation {
-    condition     = alltrue([for secret in var.task_secrets : length(secret) == 2 && contains(keys(secret), "name") && contains(keys(secret), "valueFrom")])
-    error_message = "Each secret must be of the form { name = string, valueFrom = string }."
-  }
+  description = "Secrets to set on the ECS task when it runs. This will inject sensitive data into your containers as environment variables. The full ARNs of the secrets must be provided for this module."
+  type = list(object({
+    name      = string
+    valueFrom = string
+  }))
+  default = []
 }


### PR DESCRIPTION
- Add an extra IAM policy to the execution role for ECS tasks if it needs to read secrets from AWS Secrets Manager or AWS SSM Parameter Store
- Improve validation on variables for task secrets and task environment variables
- Update some READMEs