### PR TITLE
FIX: migrate to task role names

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,5 +81,6 @@ No modules.
 | <a name="output_assumed_role_name"></a> [assumed_role_name](#output_assumed_role_name)                               | The name of the IAM role assumed by Orchestra to perform compute operations.            |
 | <a name="output_compute_cluster_arn"></a> [compute_cluster_arn](#output_compute_cluster_arn)                         | The ARN of the ECS cluster created by this module.                                      |
 | <a name="output_compute_cluster_name"></a> [compute_cluster_name](#output_compute_cluster_name)                      | The name of the ECS cluster created by this module.                                     |
+| <a name="output_integration_task_role_arns"></a> [integration_task_role_arns](#output_integration_task_role_arns)    | The ARNs of the IAM roles created for each integration compute task.                    |
 | <a name="output_integration_task_role_names"></a> [integration_task_role_names](#output_integration_task_role_names) | The names of the IAM roles created for each integration compute task.                   |
 | <a name="output_secret_store_bucket_id"></a> [secret_store_bucket_id](#output_secret_store_bucket_id)                | The name of the S3 bucket used to temporarily store secrets used during a compute task. |

--- a/README.md
+++ b/README.md
@@ -74,12 +74,12 @@ No modules.
 
 ## Outputs
 
-| Name                                                                                                              | Description                                                                             |
-| ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| <a name="output_artifact_store_bucket_id"></a> [artifact_store_bucket_id](#output_artifact_store_bucket_id)       | The name of the S3 bucket used to store artifacts generated during a compute task.      |
-| <a name="output_assumed_role_arn"></a> [assumed_role_arn](#output_assumed_role_arn)                               | The ARN of the IAM role assumed by Orchestra to perform compute operations.             |
-| <a name="output_assumed_role_name"></a> [assumed_role_name](#output_assumed_role_name)                            | The name of the IAM role assumed by Orchestra to perform compute operations.            |
-| <a name="output_compute_cluster_arn"></a> [compute_cluster_arn](#output_compute_cluster_arn)                      | The ARN of the ECS cluster created by this module.                                      |
-| <a name="output_compute_cluster_name"></a> [compute_cluster_name](#output_compute_cluster_name)                   | The name of the ECS cluster created by this module.                                     |
-| <a name="output_integration_task_role_arns"></a> [integration_task_role_arns](#output_integration_task_role_arns) | The ARNs of the IAM roles created for each integration compute task.                    |
-| <a name="output_secret_store_bucket_id"></a> [secret_store_bucket_id](#output_secret_store_bucket_id)             | The name of the S3 bucket used to temporarily store secrets used during a compute task. |
+| Name                                                                                                                 | Description                                                                             |
+| -------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| <a name="output_artifact_store_bucket_id"></a> [artifact_store_bucket_id](#output_artifact_store_bucket_id)          | The name of the S3 bucket used to store artifacts generated during a compute task.      |
+| <a name="output_assumed_role_arn"></a> [assumed_role_arn](#output_assumed_role_arn)                                  | The ARN of the IAM role assumed by Orchestra to perform compute operations.             |
+| <a name="output_assumed_role_name"></a> [assumed_role_name](#output_assumed_role_name)                               | The name of the IAM role assumed by Orchestra to perform compute operations.            |
+| <a name="output_compute_cluster_arn"></a> [compute_cluster_arn](#output_compute_cluster_arn)                         | The ARN of the ECS cluster created by this module.                                      |
+| <a name="output_compute_cluster_name"></a> [compute_cluster_name](#output_compute_cluster_name)                      | The name of the ECS cluster created by this module.                                     |
+| <a name="output_integration_task_role_names"></a> [integration_task_role_names](#output_integration_task_role_names) | The names of the IAM roles created for each integration compute task.                   |
+| <a name="output_secret_store_bucket_id"></a> [secret_store_bucket_id](#output_secret_store_bucket_id)                | The name of the S3 bucket used to temporarily store secrets used during a compute task. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,3 +32,8 @@ output "integration_task_role_names" {
   value       = { for k, v in aws_iam_role.ecs_compute_task_roles : k => v.name }
   description = "The names of the IAM roles created for each integration compute task."
 }
+
+output "integration_task_role_arns" {
+  value       = { for k, v in aws_iam_role.ecs_compute_task_roles : k => v.arn }
+  description = "The ARNs of the IAM roles created for each integration compute task."
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -28,7 +28,7 @@ output "secret_store_bucket_id" {
   description = "The name of the S3 bucket used to temporarily store secrets used during a compute task."
 }
 
-output "integration_task_role_arns" {
-  value       = aws_iam_role.ecs_compute_task_roles[*].arn
-  description = "The ARNs of the IAM roles created for each integration compute task."
+output "integration_task_role_names" {
+  value       = { for k, v in aws_iam_role.ecs_compute_task_roles : k => v.name }
+  description = "The names of the IAM roles created for each integration compute task."
 }


### PR DESCRIPTION
This pull request adds support for outputting the names of IAM roles created for integration compute tasks alongside their ARNs. The changes include updates to documentation and Terraform output configuration.

### Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L78-R85): Added a new row to the outputs table for `integration_task_role_names`, describing the names of IAM roles created for integration compute tasks.

### Terraform output configuration updates:
* [`outputs.tf`](diffhunk://#diff-de6c47c2496bd028a84d55ab12d8a4f90174ebfb6544b8b5c7b07a7ee4f27ec7R31-R37): Introduced a new output, `integration_task_role_names`, which provides the names of IAM roles created for integration compute tasks. Additionally, refactored the `integration_task_role_arns` output to use a map structure for consistency.