### PR TITLE
adding networking and permissions examples

### DIFF
--- a/examples/networking/README.md
+++ b/examples/networking/README.md
@@ -1,0 +1,17 @@
+# Networking Example
+
+This example shows how to create a secure VPC setup for the Orchestra ECS Compute module, with private subnets for workloads and NAT Gateways for outbound internet access.
+
+Note this example creates a VPC with both public and private subnets. The public subnets are used for NAT Gateways, which are required for outbound internet access from the private subnets.
+
+## Network Architecture
+
+- VPC with DNS support (but no public DNS hostnames)
+- Private subnets across multiple availability zones
+- Public subnets (used only for NAT Gateways)
+- NAT Gateways for outbound internet access from private subnets
+- Security group allowing all internal VPC traffic and outbound internet access
+
+## Usage
+
+Be sure to get your Orchestra account ID from the [Account Settings](https://app.getorchestra.io/settings/account) page in Orchestra.

--- a/examples/networking/main.tf
+++ b/examples/networking/main.tf
@@ -1,0 +1,12 @@
+module "ecs-compute" {
+  source = "orchestra-hq/ecs-compute/aws"
+
+  name_prefix  = var.name_prefix
+  region       = var.region
+  integrations = ["dbt_core", "python"]
+  tags = {
+    Environment = "Demo"
+  }
+
+  orchestra_account_id = var.orchestra_account_id
+}

--- a/examples/networking/networking.tf
+++ b/examples/networking/networking.tf
@@ -1,0 +1,150 @@
+locals {
+  azs = ["${var.region}a", "${var.region}b", "${var.region}c"]
+}
+
+########################################################
+# VPC
+########################################################
+resource "aws_vpc" "main" {
+  cidr_block         = var.vpc_cidr
+  enable_dns_support = true
+
+  tags = {
+    Name = "${var.name_prefix}-vpc"
+  }
+}
+
+########################################################
+# Public Subnets
+########################################################
+resource "aws_subnet" "public" {
+  count             = length(local.azs)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, count.index)
+  availability_zone = local.azs[count.index]
+
+  tags = {
+    Name = "${var.name_prefix}-public-subnet-${count.index + 1}"
+  }
+}
+
+########################################################
+# Internet Gateway
+########################################################
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${var.name_prefix}-igw"
+  }
+}
+
+########################################################
+# Public Route Table
+########################################################
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-public-rt"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(local.azs)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+########################################################
+# Private Subnets
+########################################################
+resource "aws_subnet" "private" {
+  count             = length(local.azs)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, count.index + length(local.azs))
+  availability_zone = local.azs[count.index]
+
+  tags = {
+    Name = "${var.name_prefix}-private-subnet-${count.index + 1}"
+  }
+}
+
+########################################################
+# NAT Gateways
+########################################################
+resource "aws_eip" "nat" {
+  count  = length(local.azs)
+  domain = "vpc"
+
+  tags = {
+    Name = "${var.name_prefix}-nat-eip-${count.index + 1}"
+  }
+}
+
+resource "aws_nat_gateway" "main" {
+  count         = length(local.azs)
+  subnet_id     = aws_subnet.public[count.index].id
+  allocation_id = aws_eip.nat[count.index].id
+
+  tags = {
+    Name = "${var.name_prefix}-nat-${count.index + 1}"
+  }
+
+  depends_on = [aws_internet_gateway.main]
+}
+
+########################################################
+# Private Route Tables
+########################################################
+resource "aws_route_table" "private" {
+  count  = length(local.azs)
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.main[count.index].id
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-private-rt-${count.index + 1}"
+  }
+}
+
+resource "aws_route_table_association" "private" {
+  count          = length(local.azs)
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[count.index].id
+}
+
+########################################################
+# Security Group
+########################################################
+resource "aws_security_group" "main" {
+  name        = "${var.name_prefix}-sg"
+  description = "Security group for ${var.name_prefix}"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = [var.vpc_cidr]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-sg"
+  }
+}

--- a/examples/networking/outputs.tf
+++ b/examples/networking/outputs.tf
@@ -1,0 +1,49 @@
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = aws_vpc.main.id
+}
+
+output "public_subnet_ids" {
+  description = "List of public subnet IDs"
+  value       = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  description = "List of private subnet IDs"
+  value       = aws_subnet.private[*].id
+}
+
+output "security_group_id" {
+  description = "The ID of the security group"
+  value       = aws_security_group.main.id
+}
+
+output "compute_cluster_name" {
+  description = "The name of the ECS cluster created by this module."
+  value       = module.ecs-compute.compute_cluster_name
+}
+
+output "compute_cluster_arn" {
+  description = "The ARN of the ECS cluster created by this module."
+  value       = module.ecs-compute.compute_cluster_arn
+}
+
+output "assumed_role_arn" {
+  description = "The ARN of the IAM role assumed by Orchestra to perform compute operations."
+  value       = module.ecs-compute.assumed_role_arn
+}
+
+output "assumed_role_name" {
+  description = "The name of the IAM role assumed by Orchestra to perform compute operations."
+  value       = module.ecs-compute.assumed_role_name
+}
+
+output "artifact_store_bucket_id" {
+  description = "The name of the S3 bucket used to store artifacts generated during a compute task."
+  value       = module.ecs-compute.artifact_store_bucket_id
+}
+
+output "secret_store_bucket_id" {
+  description = "The name of the S3 bucket used to temporarily store secrets used during a compute task."
+  value       = module.ecs-compute.secret_store_bucket_id
+}

--- a/examples/networking/variables.tf
+++ b/examples/networking/variables.tf
@@ -1,0 +1,23 @@
+variable "name_prefix" {
+  description = "Prefix to be used for resource names"
+  type        = string
+  default     = "networking-example"
+}
+
+variable "region" {
+  description = "AWS region to deploy resources"
+  type        = string
+  default     = "eu-west-2"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "orchestra_account_id" {
+  description = "Your Orchestra account ID"
+  type        = string
+  default     = "4a6a45ca-5549-4c53-bca4-43a76e1bab2c"
+}

--- a/examples/permissions/README.md
+++ b/examples/permissions/README.md
@@ -1,0 +1,12 @@
+# Permissions
+
+This example demonstrates how to add custom IAM permissions to the ECS compute cluster's task roles. In this case, we're adding permissions to list objects in an S3 bucket.
+
+This allows the Python compute tasks run from Orchestra to list objects in an S3 bucket.
+
+## Configuration
+
+The example adds an IAM policy that allows the Python task role to:
+
+- List objects in an S3 bucket (`s3:ListBucket`)
+- Get the bucket location (`s3:GetBucketLocation`)

--- a/examples/permissions/iam.tf
+++ b/examples/permissions/iam.tf
@@ -1,0 +1,23 @@
+# Allows the python task role to list objects in an S3 bucket
+resource "aws_iam_policy" "allow_s3_listing" {
+  name        = "allow-s3-listing"
+  description = "Policy to allow listing objects in an S3 bucket"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:ListBucket",
+          "s3:GetBucketLocation"
+        ],
+        Resource = "arn:aws:s3:::example-bucket-name" # Replace with your bucket name
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_compute_python_task_role_s3_attachment" {
+  role       = module.ecs-compute.integration_task_role_names["python"]
+  policy_arn = aws_iam_policy.allow_s3_listing.arn
+}

--- a/examples/permissions/main.tf
+++ b/examples/permissions/main.tf
@@ -3,7 +3,7 @@ module "ecs-compute" {
 
   name_prefix  = "awesome-compute"
   region       = "eu-west-2"
-  integrations = ["dbt_core", "python"]
+  integrations = ["python"]
   tags = {
     Owner = "Awesome Team"
   }

--- a/examples/secrets/main.tf
+++ b/examples/secrets/main.tf
@@ -4,7 +4,7 @@ module "ecs-compute" {
 
   name_prefix          = "awesome-compute"
   region               = "eu-west-2"
-  integrations         = ["dbt-core", "python"]
+  integrations         = ["dbt_core", "python"]
   orchestra_account_id = "4a6a45ca-5549-4c53-bca4-43a76e1bab2c"
 
   task_secrets = [


### PR DESCRIPTION
This pull request introduces two new examples (`networking` and `permissions`) and updates existing examples (`secrets` and `standard`) to improve consistency in naming conventions. The `networking` example demonstrates how to set up a secure VPC architecture for Orchestra ECS Compute, and the `permissions` example showcases adding custom IAM permissions for compute tasks. Below are the most important changes grouped by theme.

### Networking Example Setup:
* Added a `README.md` file describing the secure VPC setup with private subnets, NAT Gateways, and security groups for Orchestra ECS Compute workloads.
* Defined resources in `networking.tf` for creating a VPC, public/private subnets, NAT Gateways, route tables, and security groups.
* Added outputs in `outputs.tf` to expose VPC, subnet IDs, security group ID, and ECS cluster details.
* Introduced variables in `variables.tf` for resource naming, region, VPC CIDR, and Orchestra account ID.
* Configured the `ecs-compute` module in `main.tf` for integration with Orchestra ECS Compute.

### Permissions Example Setup:
* Added a `README.md` file explaining how to add IAM permissions for ECS compute tasks to interact with S3 buckets.
* Defined IAM resources in `iam.tf` to allow Python tasks to list objects and get bucket location in S3.
* Configured the `ecs-compute` module in `main.tf` with the "python" integration.

### Consistency Updates:
* Updated `examples/secrets/main.tf` and `examples/standard/main.tf` to replace `dbt-core` with `dbt_core` in the `integrations` parameter for consistency. [[1]](diffhunk://#diff-d58ee74f59b80cb740a310c80f538789008ffe04ddf11f2ba20411a6f7181062L7-R7) [[2]](diffhunk://#diff-598bcdf79b4a4c4d50eb13952a0c0c49e47dfb6118f72b5676a795d9cadf3f1aL6-R6)