### PR TITLE
Create new alias for kms key

### DIFF
--- a/key.tf
+++ b/key.tf
@@ -30,3 +30,10 @@ resource "aws_kms_alias" "orchestra_key" {
   name          = "alias/integration_${upper(each.value)}"
   target_key_id = aws_kms_key.orchestra_key.key_id
 }
+
+resource "aws_kms_alias" "orchestra_key_alias" {
+  for_each = toset(local.integrations)
+
+  name          = "alias/${var.name_prefix}_integration_${upper(each.value)}_${random_id.random_suffix.hex}"
+  target_key_id = aws_kms_key.orchestra_key.key_id
+}


### PR DESCRIPTION
This pull request introduces a new resource definition in the `key.tf` file to enhance the flexibility of KMS alias creation. The change adds a mechanism for generating unique aliases for integrations by appending a random suffix.

Key changes:

### Resource addition for KMS alias management:
* [`key.tf`](diffhunk://#diff-2e1cd3469f5aa670a0b75cf01c6f62559224441ccb921bb1a29aceb7fdc3c82dR33-R39): Added a new `aws_kms_alias` resource named `orchestra_key_alias` to dynamically create unique aliases for integrations using a random suffix (`random_id.random_suffix.hex`). This ensures each alias is distinct and avoids potential naming conflicts.