### PR TITLE
FEAT: add unique task definition with name prefix and random suffix

### DIFF
--- a/task_definition.tf
+++ b/task_definition.tf
@@ -22,10 +22,53 @@ locals {
   ])
 }
 
-resource "aws_ecs_task_definition" "task_definition" {
+resource "aws_ecs_task_definition" "task_definition_old" {
   for_each = { for task in local.task_defs : "${task.integration}_${task.python_version}" => task }
 
   family                   = "${each.key}_PIP"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = each.value.cpu
+  memory                   = each.value.memory
+
+  execution_role_arn = aws_iam_role.compute_execute_role.arn
+
+  container_definitions = jsonencode([
+    {
+      name        = each.value.integration
+      image       = "${local.ecr_account_mapping[var.orchestra_aws_account_id]}.dkr.ecr.${var.region}.amazonaws.com/${each.value.image}:${each.value.python_version}_PIP-${var.image_tags[each.value.integration]}"
+      cpu         = each.value.cpu
+      memory      = each.value.memory
+      environment = var.task_env_vars,
+      secrets     = var.task_secrets,
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.compute_log_group.name
+          "awslogs-region"        = var.region
+          "awslogs-stream-prefix" = each.value.integration
+        }
+      }
+    }
+  ])
+
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "ARM64"
+  }
+
+  tags = merge(
+    local.tags,
+    {
+      "NewLogGroup" = "true"
+    }
+  )
+}
+
+resource "aws_ecs_task_definition" "task_definition" {
+  for_each = { for task in local.task_defs : "${task.integration}_${task.python_version}" => task }
+
+  family                   = "${var.name_prefix}_${each.key}_${random_id.random_suffix.hex}_PIP"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = each.value.cpu


### PR DESCRIPTION
This pull request introduces changes to the `task_definition.tf` file to create a new ECS task definition resource while preserving the existing one under a different name. The new task definition includes enhanced configurations such as Fargate compatibility, ARM64 architecture support, and improved logging setup.

### ECS Task Definition Updates:

* **Renaming existing task definition**: The `aws_ecs_task_definition` resource previously named `task_definition` has been renamed to `task_definition_old` to retain the existing configuration while introducing a new resource.

* **Adding new ECS task definition**: A new `aws_ecs_task_definition` resource named `task_definition` has been added with the following features:
  - **Fargate compatibility**: Configured with `network_mode = "awsvpc"` and `requires_compatibilities = ["FARGATE"]`.
  - **Runtime platform**: Supports `LINUX` operating system family and `ARM64` CPU architecture.
  - **Enhanced logging**: Uses AWS CloudWatch Logs with a new log group and stream prefix based on the task integration.
  - **Dynamic container definitions**: Includes environment variables, secrets, and dynamically generated image tags for each task.
  - **Tagging**: Adds new tags, including `"NewLogGroup" = "true"`.