### PR TITLE
Remove old key alias and old task definition

### DIFF
--- a/key.tf
+++ b/key.tf
@@ -24,13 +24,6 @@ resource "aws_kms_key" "orchestra_key" {
   tags = local.tags
 }
 
-resource "aws_kms_alias" "orchestra_key" {
-  for_each = toset(local.integrations)
-
-  name          = "alias/integration_${upper(each.value)}"
-  target_key_id = aws_kms_key.orchestra_key.key_id
-}
-
 resource "aws_kms_alias" "orchestra_key_alias" {
   for_each = toset(local.integrations)
 

--- a/task_definition.tf
+++ b/task_definition.tf
@@ -22,49 +22,6 @@ locals {
   ])
 }
 
-resource "aws_ecs_task_definition" "task_definition_old" {
-  for_each = { for task in local.task_defs : "${task.integration}_${task.python_version}" => task }
-
-  family                   = "${each.key}_PIP"
-  network_mode             = "awsvpc"
-  requires_compatibilities = ["FARGATE"]
-  cpu                      = each.value.cpu
-  memory                   = each.value.memory
-
-  execution_role_arn = aws_iam_role.compute_execute_role.arn
-
-  container_definitions = jsonencode([
-    {
-      name        = each.value.integration
-      image       = "${local.ecr_account_mapping[var.orchestra_aws_account_id]}.dkr.ecr.${var.region}.amazonaws.com/${each.value.image}:${each.value.python_version}_PIP-${var.image_tags[each.value.integration]}"
-      cpu         = each.value.cpu
-      memory      = each.value.memory
-      environment = var.task_env_vars,
-      secrets     = var.task_secrets,
-      logConfiguration = {
-        logDriver = "awslogs"
-        options = {
-          "awslogs-group"         = aws_cloudwatch_log_group.compute_log_group.name
-          "awslogs-region"        = var.region
-          "awslogs-stream-prefix" = each.value.integration
-        }
-      }
-    }
-  ])
-
-  runtime_platform {
-    operating_system_family = "LINUX"
-    cpu_architecture        = "ARM64"
-  }
-
-  tags = merge(
-    local.tags,
-    {
-      "NewLogGroup" = "true"
-    }
-  )
-}
-
 resource "aws_ecs_task_definition" "task_definition" {
   for_each = { for task in local.task_defs : "${task.integration}_${task.python_version}" => task }
 


### PR DESCRIPTION
This pull request primarily removes outdated resources and configurations from the Terraform codebase, simplifying the infrastructure definition. The changes focus on cleaning up unused aliases and task definitions while ensuring the updated resources remain functional.

### Removal of outdated resources:

* [`key.tf`](diffhunk://#diff-2e1cd3469f5aa670a0b75cf01c6f62559224441ccb921bb1a29aceb7fdc3c82dL27-L33): Deleted the `aws_kms_alias "orchestra_key"` resource, which was previously used for integration-specific aliases. The updated code retains only the `aws_kms_alias "orchestra_key_alias"` resource for integrations.

* [`task_definition.tf`](diffhunk://#diff-8a5407c77b93d086abd2d929d59c0f41c302c80bd44a9d7b31ac9cd6d76004fbL25-L67): Removed the `aws_ecs_task_definition "task_definition_old"` resource, which included configurations for ECS task definitions with older settings. The updated code retains the `aws_ecs_task_definition "task_definition"` resource with current configurations.