### PR TITLE
Force the destruction of S3 buckets on `terraform destroy`

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,6 +1,7 @@
 resource "aws_s3_bucket" "secret_store" {
-  bucket = "${var.name_prefix}-orchestra-secrets-${random_id.random_suffix.hex}"
-  tags   = local.tags
+  bucket        = "${var.name_prefix}-orchestra-secrets-${random_id.random_suffix.hex}"
+  force_destroy = true
+  tags          = local.tags
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "secret_store_lifecycle_config" {
@@ -25,8 +26,9 @@ resource "aws_s3_bucket_lifecycle_configuration" "secret_store_lifecycle_config"
 }
 
 resource "aws_s3_bucket" "artifact_store" {
-  bucket = "${var.name_prefix}-orchestra-artifacts-${random_id.random_suffix.hex}"
-  tags   = local.tags
+  bucket        = "${var.name_prefix}-orchestra-artifacts-${random_id.random_suffix.hex}"
+  force_destroy = true
+  tags          = local.tags
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "artifact_store_lifecycle_config" {


### PR DESCRIPTION
- Currently, if there is a slight misconfiguration in the setup, some items in the bucket may remain in place when attempting to destroy resources
- In this case, Terraform will fail to delete all the resources
- We should `force_delete` the S3 buckets on deletion