### PR TITLE
FIX: update resources for assumed role

### DIFF
--- a/assumed_role.tf
+++ b/assumed_role.tf
@@ -1,11 +1,3 @@
-locals {
-  task_definitions = flatten([
-    for integration in local.integrations : [
-      "arn:aws:ecs:${var.region}:${data.aws_caller_identity.current.account_id}:task-definition/${integration}_*",
-    ]
-  ])
-}
-
 resource "aws_iam_role" "role_assumed_from_orchestra" {
   name        = "${var.name_prefix}-orchestra-compute-${random_id.random_suffix.hex}"
   description = "IAM role assumed by Orchestra to for configuring compute operations."
@@ -90,7 +82,7 @@ data "aws_iam_policy_document" "role_assumed_from_orchestra_policy_doc" {
       "ecs:RunTask",
       "ecs:TagResource"
     ]
-    resources = local.task_definitions
+    resources = aws_ecs_task_definition.task_definition[*].arn
   }
 
   statement {


### PR DESCRIPTION
This pull request simplifies the handling of ECS task definitions in the `assumed_role.tf` file by removing the `locals` block and directly referencing the task definition ARNs using the `aws_ecs_task_definition` resource. These changes improve clarity and reduce unnecessary complexity.

Resource simplification:

* [`assumed_role.tf`](diffhunk://#diff-14d18898f723e3c8ef394846d523a66af09619b90e8224932021366ac4456390L1-L8): Removed the `locals` block that previously flattened and constructed ECS task definition ARNs from integrations. The task definition ARNs are now directly referenced using `aws_ecs_task_definition.task_definition[*].arn`. [[1]](diffhunk://#diff-14d18898f723e3c8ef394846d523a66af09619b90e8224932021366ac4456390L1-L8) [[2]](diffhunk://#diff-14d18898f723e3c8ef394846d523a66af09619b90e8224932021366ac4456390L93-R85)