### PR TITLE
Add permission to read networking config on compute account

### DIFF
--- a/assumed_role.tf
+++ b/assumed_role.tf
@@ -124,6 +124,17 @@ data "aws_iam_policy_document" "role_assumed_from_orchestra_policy_doc" {
       aws_ecs_cluster.ecs_compute_cluster.arn,
     ]
   }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeSubnets"
+    ]
+    resources = [
+      "*"
+    ]
+  }
 }
 
 resource "aws_iam_policy" "role_assumed_from_orchestra_policy" {


### PR DESCRIPTION
- Add permissions to validate security groups and subnet IDs when inputted by the user