### PR TITLE
FIX: use correct arn value for task defintions

### DIFF
--- a/assumed_role.tf
+++ b/assumed_role.tf
@@ -82,7 +82,7 @@ data "aws_iam_policy_document" "role_assumed_from_orchestra_policy_doc" {
       "ecs:RunTask",
       "ecs:TagResource"
     ]
-    resources = aws_ecs_task_definition.task_definition[*].arn
+    resources = [for arn in values(aws_ecs_task_definition.task_definition)[*].arn : replace(arn, "/:\\d+$/", ":*")]
   }
 
   statement {


### PR DESCRIPTION
This pull request updates the resource specification for an IAM policy in `assumed_role.tf` to ensure compatibility with ECS task definitions.

IAM Policy Update:

* [`assumed_role.tf`](diffhunk://#diff-14d18898f723e3c8ef394846d523a66af09619b90e8224932021366ac4456390L85-R85): Modified the `resources` attribute in the `aws_iam_policy_document` data block to use a `replace` function. This ensures ECS task definition ARNs are formatted correctly by replacing numeric suffixes with a wildcard (`:*`).