### PR TITLE
Remove version from the secrets example

### DIFF
--- a/examples/secrets/main.tf
+++ b/examples/secrets/main.tf
@@ -1,6 +1,5 @@
 module "ecs-compute" {
-  source  = "orchestra-hq/ecs-compute/aws"
-  version = "0.0.3"
+  source = "orchestra-hq/ecs-compute/aws"
 
   name_prefix          = "awesome-compute"
   region               = "eu-west-2"


### PR DESCRIPTION
This pull request makes a minor update to the `examples/secrets/main.tf` file, specifically removing the version specification for the `ecs-compute` module. This change likely allows the module to use its default or latest version.